### PR TITLE
Add FEAT verb

### DIFF
--- a/ftp-proxy/ftp-cmds.c
+++ b/ftp-proxy/ftp-cmds.c
@@ -165,6 +165,7 @@ static CMD cmdlist[] = {
 	{ "XPWD", cmds_pthr, REST },
 	{ "XCUP", cmds_pthr, REST },
 	{ "RCMD", cmds_pthr, REST },
+	{ "FEAT", cmds_pthr, REST },    /* required for MTDM support */
 #if defined(ENABLE_SSL) /* <!-- SSL --> */
 	{ "AUTH", cmds_auth, REST },	/* Only needed for SSL	*/
 #endif /* <!-- /SSL --> */


### PR DESCRIPTION
Required if client is going to use MTDM support, as client determines if this is supported by sending the FEAT verb
MTDM provides timezone support.

I had an issue where the timezone returned by list was in the servers timezone and we required it in the clients timezone.
I found the FEAT verb was being rejected.
This patch adds FEAT verb support. Once applied FEAT was passed on to the server and it replied with MTDM (and other features). This enabled the client to use MTDM and solved my issue.
The client was filezilla and winscp
